### PR TITLE
Add decimal values to missing ticks

### DIFF
--- a/components/charts/barschart/barschart-config.js
+++ b/components/charts/barschart/barschart-config.js
@@ -15,7 +15,7 @@ export default {
   // styling
   strokeDasharray: '3',
   fill: 'none',
-  YAxisTicks: ['0', '0.200', '0.400', '0.600', '0.800', '1'],
+  YAxisTicks: ['0.000', '0.200', '0.400', '0.600', '0.800', '1.000'],
   // bar
   barDataKey: 'value',
   setBarFill: () => '#ddd',

--- a/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-constants.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-constants.js
@@ -3,7 +3,7 @@ export const CHART_CONFIG = {
   barSize: 85,
   setBarFill: () => '#bf3132',
   domain: [0, 6],
-  YAxisTicks: ['0', '1.0', '2.0', '3.0', '4.0', '5.0', '6.0']
+  YAxisTicks: ['0.0', '1.0', '2.0', '3.0', '4.0', '5.0', '6.0']
 };
 
 export default { CHART_CONFIG };


### PR DESCRIPTION
## Overview
They want the decimal values on 0 and 1 values.

## Testing instructions
Changed the ticks on companies overall bars and mine site detail bars.

## Pivotal task
[Task](https://basecamp.com/1756858/projects/14775080/todos/344932154)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
