### PR TITLE
Add dates to company detail info

### DIFF
--- a/components/pages/companies-detail/companies-detail-sidebar/companies-detail-sidebar-component.js
+++ b/components/pages/companies-detail/companies-detail-sidebar/companies-detail-sidebar-component.js
@@ -13,7 +13,10 @@ class CompaniesDetailSidebar extends PureComponent {
       'pretax-revenues-busd': preTaxRevenuesBusd,
       'number-workers': workers,
       'number-employees': employees,
-      'fatality-reports': fatalityReports
+      'fatality-reports': fatalityReports,
+      'revenues-date': revenuesDate,
+      'number-workers-date': workersDate,
+      'number-employees-date': employeesDate
     } = company[0] || {};
     const { name: countryName } = country || {};
 
@@ -48,7 +51,10 @@ class CompaniesDetailSidebar extends PureComponent {
               {preTaxRevenuesBusd !== null &&
                 <div className="definition-item">
                   <div className="definition-key">Pre-tax Revenues (in BUSD):</div>
-                  <div className="definition-value">{preTaxRevenuesBusd.toLocaleString()}</div>
+                  <div className="definition-value">
+                    {preTaxRevenuesBusd.toLocaleString()}
+                    <span>{revenuesDate ? ` (${revenuesDate})` : ''}</span>
+                  </div>
                 </div>}
             </div>
           </div>
@@ -57,14 +63,20 @@ class CompaniesDetailSidebar extends PureComponent {
               {workers !== null &&
                 <div className="definition-item">
                   <div className="definition-key">Number of workers:</div>
-                  <div className="definition-value">{workers.toLocaleString()}</div>
+                  <div className="definition-value">
+                    {workers.toLocaleString()}
+                    <span>{workersDate ? ` (${workersDate})` : ''}</span>
+                  </div>
                 </div>}
             </div>
             <div className="col-xs-12 col-md-6">
               {employees !== null &&
                 <div className="definition-item">
                   <div className="definition-key">Number of employees:</div>
-                  <div className="definition-value">{employees.toLocaleString()}</div>
+                  <div className="definition-value">
+                    {employees.toLocaleString()}
+                    <span>{employeesDate ? ` (${employeesDate})` : ''}</span>
+                  </div>
                 </div>}
             </div>
           </div>

--- a/components/pages/mine-sites-detail/mine-sites-detail-country-comparison/mine-sites-detail-country-comparison-component.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-country-comparison/mine-sites-detail-country-comparison-component.js
@@ -27,9 +27,9 @@ class MineSitesDetailCountryComparison extends PureComponent {
         <table className="country-comparison-table">
           <thead>
             <tr>
-              <th className="country-header">Producing Country</th>
-              <th />
               <th className="country-header">Home Country</th>
+              <th />
+              <th className="country-header">Producing Country</th>
             </tr>
             <tr>
               <th className="country-value">{producingCountryName}</th>

--- a/css/components/detail-sidebar.scss
+++ b/css/components/detail-sidebar.scss
@@ -17,6 +17,10 @@
       margin: 5px 0 0;
       font-weight: $font-weight-bold;
       line-height: 1.2;
+
+      > span {
+        font-weight: $font-weight-light;
+      }
     }
   }
 


### PR DESCRIPTION
## Overview
Added the dates for the information on the company detail, they should not be bolded with the main info.

Switch headers on home/producing country table on the mine site detail page.

## Testing instructions
On company detail the _Pre-tax Revenues (in BUSD):_, _Number of workers:_ and _Number of employees:_ fields should have the date in parenthesis if known.

Check bottom table on mine site detail page and check if home/producing countries make sense.

## Pivotal task
[Task](https://basecamp.com/1756858/projects/14775080/todos/343669119)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
