### PR TITLE
Adjust lists of mine sites

### DIFF
--- a/components/common/companies-list/companies-list-item.js
+++ b/components/common/companies-list/companies-list-item.js
@@ -30,7 +30,7 @@ class CompaniesListItem extends PureComponent {
 
   render() {
     const { isCompanyPage, company } = this.props;
-    const { name, id, 'mine-sites': mineSites } = company;
+    const { name, id, 'selected-mine-sites': mineSites } = company;
     const { visibility } = this.state;
 
     if (isCompanyPage) {

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-selectors.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-selectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import groupBy from 'lodash/groupBy';
 
 const scores = state => (state.companies.list[0] || {}).scores;
-const mineSites = state => (state.companies.list[0] || {})['mine-sites'];
+const selectedMineSites = state => (state.companies.list[0] || {})['selected-mine-sites'];
 const shareholders = state => (state.companies.list[0] || {}).shareholders;
 const subsidiaries = state => (state.companies.list[0] || {}).subsidiaries;
 const beneficialOwners = state => (state.companies.list[0] || {})['beneficial-owners'];
@@ -24,9 +24,9 @@ export const getOverallScores = createSelector(
 );
 
 export const parseMineSitesScores = createSelector(
-  [mineSites],
-  (_mineSites = []) =>
-    _mineSites.map(mineSite => ({
+  [selectedMineSites],
+  (_selectedMineSites = []) =>
+    _selectedMineSites.map(mineSite => ({
       id: mineSite.id,
       name: mineSite.name,
       localProcurment: ((mineSite.scores || []).find(score => score.slug.includes('ms-01-1')) || {}).value,

--- a/components/pages/companies-detail/companies-details-selectors.js
+++ b/components/pages/companies-detail/companies-details-selectors.js
@@ -48,7 +48,7 @@ export const getIssueAreas = createSelector(
 export const getMarkers = createSelector(
   company,
   (_company = {}) =>
-    (_company['mine-sites'] || []).map(mineSite => ({
+    (_company['selected-mine-sites'] || []).map(mineSite => ({
       id: mineSite.id,
       name: mineSite.name,
       coordinates: [mineSite['coord-y'], mineSite['coord-x']]

--- a/components/pages/mine-sites/mine-sites-selectors.js
+++ b/components/pages/mine-sites/mine-sites-selectors.js
@@ -36,7 +36,7 @@ export const getMarkers = createSelector(
     const mineSites = [];
 
     _companies.forEach(company =>
-      company['mine-sites'].forEach((mineSite) => {
+      company['selected-mine-sites'].forEach((mineSite) => {
         mineSites.push(({
           id: mineSite.id,
           name: mineSite.name,

--- a/pages/companies/companies-page-component.js
+++ b/pages/companies/companies-page-component.js
@@ -32,7 +32,7 @@ class CompaniesPage extends Page {
           include: ['country', 'secondary-country', 'producing-countries', 'mine-sites', 'mine-sites.country',
             'mine-sites.commodities', 'mine-sites.scores', 'scores', 'shareholders', 'subsidiaries',
             'beneficial-owners', 'company-country-tax-jurisdictions', 'company-country-tax-jurisdictions.country',
-            'investment-disputes', 'fatality-reports'
+            'investment-disputes', 'fatality-reports', 'selected-mine-sites'
           ].join(','),
           'page[size]': 9999
         }

--- a/pages/mine-sites/mine-sites-page.js
+++ b/pages/mine-sites/mine-sites-page.js
@@ -37,7 +37,7 @@ class MineSitesPage extends Page {
       // gets documents
       await context.store.dispatch(getDocuments({ 'filter[mine-site]': context.query.mineSite }));
     } else {
-      await context.store.dispatch(getCompanies({ include: ['mine-sites', 'mine-sites.country', 'mine-sites.commodities'].join(',') }));
+      await context.store.dispatch(getCompanies({ include: ['selected-mine-sites', 'selected-mine-sites.country', 'selected-mine-sites.commodities'].join(',') }));
 
       await context.store.dispatch(getCountries({
         include: ['producing-companies', 'companies', 'secondary-companies'].join(','),


### PR DESCRIPTION
## Overview
On the api we could only ever see the selected mine sites, because of this we would never see the closed/sold mine sites tables on the company detail.

I changed the api to show only the mine sites that are in the RMI scope, this includes the selected, sold and closed mine sites, then adjusted the front to call for either all available mine sites or only the selected ones.

## Testing instructions
- [x] Check the mine sites tables on company detail (Selected, list of all, closed and sold).
- [x] Check the mine sites pages to see if clicking on companies or looking at the map, only the selected mine sites are visible.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/155933025)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
