### PR TITLE
Add locale to value when it's a number

### DIFF
--- a/components/pages/companies-detail/companies-detail-sidebar/companies-detail-sidebar-component.js
+++ b/components/pages/companies-detail/companies-detail-sidebar/companies-detail-sidebar-component.js
@@ -64,17 +64,17 @@ class CompaniesDetailSidebar extends PureComponent {
                 <div className="definition-item">
                   <div className="definition-key">Number of workers:</div>
                   <div className="definition-value">
-                    {workers.toLocaleString()}
+                    {parseInt(workers) ? (+workers).toLocaleString() : workers}
                     <span>{workersDate && ` (${workersDate})`}</span>
                   </div>
-                </div>} 
+                </div>}
             </div>
             <div className="col-xs-12 col-md-6">
               {employees !== null &&
                 <div className="definition-item">
                   <div className="definition-key">Number of employees:</div>
                   <div className="definition-value">
-                    {employees.toLocaleString()}
+                    {parseInt(employees) ? (+employees).toLocaleString() : employees}
                     <span>{employeesDate && ` (${employeesDate})`}</span>
                   </div>
                 </div>}


### PR DESCRIPTION
## Overview
Values can be the string of `unknown` or a string of a number `78200`, if it's the string of a number we format it with a locale, if not just display the value.

## Testing instructions
Check if values on company detail sidebar make sense and don't break (for workers and employees).

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/156017803)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
