### PR TITLE
Remove overall minesite score from scores chart

### DIFF
--- a/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
@@ -11,10 +11,9 @@ export const getOverallScore = createSelector(
 
 export const getScores = createSelector(
   [scores],
-  (_scores = []) => _scores.map(score => ({
+  (_scores = []) => _scores.filter(score => score.kind == 'indicator_mine_site').map(score => ({
     id: score.id,
-    name: score.kind === 'overal_mine_site' ?
-      'MS' : (score.indicator || {}).code,
+    name: (score.indicator || {}).code,
     value: score.value
   }))
 );

--- a/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
@@ -12,7 +12,7 @@ export const getOverallScore = createSelector(
 
 export const getScores = createSelector(
   [scores],
-  (_scores = []) => sortBy(_scores.filter(score => score.kind == 'indicator_mine_site'), (score) => score.indicator.code).map(score => ({
+  (_scores = []) => sortBy(_scores.filter(score => score.kind == 'indicator_mine_site'), score => score.indicator.code).map(score => ({
     id: score.id,
     name: (score.indicator || {}).code,
     value: score.value

--- a/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-bars/mine-sites-detail-bars-selectors.js
@@ -1,5 +1,6 @@
 
 import { createSelector } from 'reselect';
+import sortBy from 'lodash/sortBy';
 
 
 const scores = state => (state.mineSites.list[0] || {}).scores;
@@ -11,7 +12,7 @@ export const getOverallScore = createSelector(
 
 export const getScores = createSelector(
   [scores],
-  (_scores = []) => _scores.filter(score => score.kind == 'indicator_mine_site').map(score => ({
+  (_scores = []) => sortBy(_scores.filter(score => score.kind == 'indicator_mine_site'), (score) => score.indicator.code).map(score => ({
     id: score.id,
     name: (score.indicator || {}).code,
     value: score.value


### PR DESCRIPTION
## Overview
Remove the overall score from the bars chart since it's supposed to only show the indicators scores.

## Testing instructions
Indicators score chart on mine site detail should have 6 bars.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/156096368)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
