### PR TITLE
Fix mine site properties names

### DIFF
--- a/components/pages/mine-sites-detail/mine-sites-detail-sidebar/mine-sites-detail-selectors.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-sidebar/mine-sites-detail-selectors.js
@@ -7,7 +7,7 @@ export const parseMineSite = createSelector(
   mineSite,
   _mineSite => ({
     aliases: _mineSite.aliases,
-    miningTypes: _mineSite['mining-types'],
+    miningType: _mineSite['mining-type'],
     products: _mineSite.commodities.map(commodity => commodity.name).join(', '),
     openingYear: _mineSite['opening-year'],
     acquisitionYear: _mineSite['acquisition-year'],

--- a/components/pages/mine-sites-detail/mine-sites-detail-sidebar/mine-sites-detail-sidebar-component.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-sidebar/mine-sites-detail-sidebar-component.js
@@ -7,10 +7,10 @@ class MineSitesDetailSidebar extends PureComponent {
   render() {
     const {
       aliases,
-      miningTypes,
+      miningType,
       products,
       openingYear,
-      acquistionYear,
+      acquisitionYear,
       company,
       companyShare
     } = this.props.mineSite;
@@ -28,7 +28,7 @@ class MineSitesDetailSidebar extends PureComponent {
             <div className="col-xs-12 col-md-6">
               <div className="definition-item">
                 <div className="definition-key">Mining Type/s:</div>
-                <div className="definition-value">{miningTypes || '-'}</div>
+                <div className="definition-value">{miningType || '-'}</div>
               </div>
             </div>
           </div>
@@ -50,7 +50,7 @@ class MineSitesDetailSidebar extends PureComponent {
             <div className="col-xs-12 col-md-6">
               <div className="definition-item">
                 <div className="definition-key">Acquisition Year:</div>
-                <div className="definition-value">{acquistionYear || '-'}</div>
+                <div className="definition-value">{acquisitionYear || '-'}</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Overview
Some info was not being shown on the mine sites detail, initially thought it was about the version of the dataset, but it was actually just a couple of typos.

## Testing instructions
Check if acquisition year and mine type are showing on the mine site detail page. (Mine 114 has both)

## Pivotal task
[Task](https://basecamp.com/1756858/projects/14775080/todos/345600824)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
