### PR TITLE
Remove bars charts from results overall page

### DIFF
--- a/components/pages/results-overall/results-overall-component.js
+++ b/components/pages/results-overall/results-overall-component.js
@@ -52,16 +52,6 @@ class ResultsOverall extends PureComponent {
               <div className="row">
                 <div className="col-xs-12">
                   {/* Overall charts */}
-                  <OverallGraph />
-                </div>
-              </div>
-            </div>
-          </section>
-          <section className="section -dark">
-            <div className="l-layout">
-              <div className="row">
-                <div className="col-xs-12">
-                  {/* Overall charts */}
                   <TopCompanies />
                 </div>
               </div>


### PR DESCRIPTION
## Overview
Removing the overall bar charts from results page and leaving the code for the component for now, just in case.

## Testing instructions
Check if bars are gone from the overall results page.

## Pivotal task
[Pivotal task](https://www.pivotaltracker.com/story/show/156188466)
[Basecamp task](https://basecamp.com/1756858/projects/14775080/todolists/51200494)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
