### PR TITLE
Make issue area selector on results page bigger

### DIFF
--- a/components/common/select/select-styles.scss
+++ b/components/common/select/select-styles.scss
@@ -3,6 +3,10 @@
 .c-select {
   width: 185px;
 
+  &.-big {
+    width: 80%;
+  }
+
   &.-underline {
     border-bottom-width: 1px;
     border-bottom-style: solid;

--- a/components/pages/results-detail/results-detail-component.js
+++ b/components/pages/results-detail/results-detail-component.js
@@ -43,7 +43,7 @@ class ResultsDetail extends PureComponent {
                   options={issueAreas}
                   placeholder="Select an issue area"
                   selectedValue={slug}
-                  className="-underline"
+                  className="-underline -big"
                 />
               </div>
               <div className="col-md-6">

--- a/components/pages/results-overall/results-overall-component.js
+++ b/components/pages/results-overall/results-overall-component.js
@@ -29,7 +29,7 @@ class ResultsOverall extends PureComponent {
                   onChange={this.handleAreaSelection}
                   options={issueAreas}
                   placeholder="Select an issue area"
-                  className="-underline"
+                  className="-underline -big"
                 />
               </div>
               <div className="col-md-6">


### PR DESCRIPTION
## Overview
I know this is not the solution we talked about, but I talked to Clara and this will achieve the visual effect wanted by the client and allow us to close the page.

## Testing instructions
Check if issue area selector on the overall results page is bigger and all names are in one line.

## Pivotal task
[Basecamp](https://basecamp.com/1756858/projects/14775080/todos/345427370)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
