### PR TITLE
Add icons to overall results page and invert issue area stacked bars colors

### DIFF
--- a/components/pages/results-overall/top-companies/top-companies-item.js
+++ b/components/pages/results-overall/top-companies/top-companies-item.js
@@ -5,7 +5,7 @@ import { Link } from 'routes';
 import Icon from 'components/common/icon';
 
 // constants
-// import { BAR_CONFIG, AREA_ISSUES_COLORS } from './top-companies-constants';
+import { AREA_ISSUE_COLOURS } from 'constants/graph-colors';
 
 // styles
 import styles from './top-companies-styles.scss';
@@ -15,13 +15,21 @@ class OverallGraphs extends PureComponent {
 
   render() {
     const { data } = this.props;
-    const { label, companies } = data;
+    const { label, companies, slug } = data;
 
     return (
       <div className="c-top-item">
         <style jsx>{styles}</style>
         <div className="top-header">
-          {/* <Icon name={slug}> */}
+          <div
+            className="top-icon"
+            style={{ background: AREA_ISSUE_COLOURS[slug] }}
+          >
+            <Icon
+              name={slug}
+              className="-big"
+            />
+          </div>
           <h3 className="top-name">{label}</h3>
         </div>
         <ul className="top-list">

--- a/components/pages/results-overall/top-companies/top-companies-styles.scss
+++ b/components/pages/results-overall/top-companies/top-companies-styles.scss
@@ -10,16 +10,27 @@
 
   > .top-header {
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
     text-align: center;
     padding: 0 30px;
+    align-items: center;
 
     >.top-name {
-      margin: 0 0 0 5px;
+      margin: 0 0 0 10px;
 
       font-family: $font-family-2;
       font-size: $font-size-big;
       color: $color-7;
+    }
+
+    > .top-icon {
+      width: 32px;
+      height: 32px;
+
+      > :global(svg) {
+        fill: $color-7;
+        stroke: $color-7;
+      }
     }
   }
 

--- a/constants/graph-colors.js
+++ b/constants/graph-colors.js
@@ -7,7 +7,7 @@ export const red = ['#de1F0a', '#ef3521', '#f85948', '#fa7d6f'];
 export const green = ['#69a820', '#83c13A', '#9ccd63', '#bbdf92'];
 
 export const overallColors = [red[0], blue[0], yellow[0], green[0], pink[0], brown[0]];
-export const measurementColors = [blue, brown, yellow, pink, red, green];
+export const measurementColors = [blue, brown, pink, yellow, red, green];
 
 export const HOVER_COLOUR = '#000';
 

--- a/constants/graph-colors.js
+++ b/constants/graph-colors.js
@@ -1,12 +1,12 @@
 
-export const blue = ['#0b46dd', '#255dec', '#4f80fc', '#86a8fe'];
-export const brown = ['#af8862', '#c09872', '#d0a77f', '#edcaa8'];
-export const yellow = ['#f89d0f', '#fab03b', '#fdbf5f', '#ffcF85'];
-export const pink = ['#a3196a', '#b7247a', '#ce348e', '#eb61B1'];
-export const red = ['#de1F0a', '#ef3521', '#f85948', '#fa7d6f'];
-export const green = ['#69a820', '#83c13A', '#9ccd63', '#bbdf92'];
+export const blue = ['#86a8fe', '#4f80fc', '#255dec', '#0b46dd'];
+export const brown = ['#edcaa8', '#d0a77f', '#c09872', '#af8862'];
+export const yellow = ['#ffcF85', '#fdbf5f', '#fab03b', '#f89d0f'];
+export const pink = ['#eb61B1', '#ce348e', '#b7247a', '#a3196a'];
+export const red = ['#fa7d6f', '#f85948', '#ef3521', '#de1F0a'];
+export const green = ['#bbdf92', '#9ccd63', '#83c13A', '#69a820'];
 
-export const overallColors = [red[0], blue[0], yellow[0], green[0], pink[0], brown[0]];
+export const overallColors = [red[3], blue[3], yellow[3], green[3], pink[3], brown[3]];
 export const measurementColors = [blue, brown, pink, yellow, red, green];
 
 export const HOVER_COLOUR = '#000';


### PR DESCRIPTION
## Overview
Add icons to the overall results page.

Fix company detail page stacked bars inverted colors.

## Testing instructions
Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/156190618)
[Iverted colors](https://www.pivotaltracker.com/story/show/156190653)
[Also inverted colors](https://basecamp.com/1756858/projects/14775080/todos/346254474)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
