### PR TITLE
Add legend to overall charts in company detail

### DIFF
--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-component.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-component.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Bars from 'components/charts/barschart';
 
 // constants
-import { CHART_CONFIG } from './companies-detail-overall-measurements-constants';
+import { CHART_CONFIG, OVERALL_CHARTS_TITLES } from './companies-detail-overall-measurements-constants';
 
 // styles
 import styles from './companies-detail-overall-measurements-styles.scss';
@@ -33,6 +33,9 @@ class CompaniesDetailOverallMeasurements extends PureComponent {
                   config={CHART_CONFIG}
                   data={d.children}
                 />
+                <div className="chart-legend">
+                  <h2 className="title">{OVERALL_CHARTS_TITLES[d.name]}</h2>
+                </div>
               </div>
             ))}
           </div>

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-constants.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-constants.js
@@ -3,5 +3,14 @@ export const CHART_CONFIG = {
   setBarFill: item => item.currentCompany ? '#272626' : '#f2f2f2'
 };
 
+export const OVERALL_CHARTS_TITLES = {
+  'Overall commitment': 'Commitment',
+  'Overall action': 'Action',
+  'Overall effectiveness': 'Effectiveness'
+};
 
-export default { CHART_CONFIG };
+
+export default {
+  CHART_CONFIG,
+  OVERALL_CHARTS_TITLES
+};

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
@@ -12,10 +12,10 @@
 
   .chart-legend {
     > .title {
-      text-align: center;
       font-family: $font-family-1;
       font-size: $font-size-bigger;
-      font-weight: $font-weight-regular;
+      font-weight: $font-weight-light;
+      text-align: center;
     }
   }
 }

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
@@ -1,7 +1,17 @@
+@import 'css/settings';
 
 .c-companies-detail-overall-measurements {
 
   .charts-container {
     margin: 25px 0 0;
+  }
+
+  .chart-legend {
+    > .title {
+      text-align: center;
+      font-family: $font-family-1;
+      font-size: $font-size-bigger;
+      font-weight: $font-weight-regular;
+    }
   }
 }

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-styles.scss
@@ -6,6 +6,10 @@
     margin: 25px 0 0;
   }
 
+  .title {
+    text-align: center;
+  }
+
   .chart-legend {
     > .title {
       text-align: center;


### PR DESCRIPTION
## Overview
This is only part of the task since the other part is awaiting a response, but this can be merged to speed up the process.

## Testing instructions
Check if the overall charts on the company detail page have a legend each.

## Pivotal task
[BC task](https://basecamp.com/1756858/projects/14775080/todos/346407524)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
