### PR TITLE
Adjust avg/min/max score comparison bar based on the page

### DIFF
--- a/components/common/score-comparison/score-comparison-component.js
+++ b/components/common/score-comparison/score-comparison-component.js
@@ -44,7 +44,7 @@ class ScoreComparison extends PureComponent {
           </div>
 
           {
-            (min != undefined) && <div
+            (min !== undefined) && <div
               className="score-min"
               style={{ left: ScoreComparison.getWidth(min) }}
             >

--- a/components/common/score-comparison/score-comparison-component.js
+++ b/components/common/score-comparison/score-comparison-component.js
@@ -17,8 +17,8 @@ class ScoreComparison extends PureComponent {
 
   render() {
     const { data, config } = this.props;
-    const { avg, min, max, value, hideInnerValue } = data;
-    const { color } = config;
+    const { avg, min, max, value } = data;
+    const { color, hideInnerValue } = config;
 
     return (
       <div className="c-score-comparison">

--- a/components/common/score-comparison/score-comparison-component.js
+++ b/components/common/score-comparison/score-comparison-component.js
@@ -1,5 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+// utils
 import { fixedValue } from 'utils/value-parser';
 
 // styles
@@ -19,6 +22,10 @@ class ScoreComparison extends PureComponent {
     const { data, config } = this.props;
     const { avg, min, max, value } = data;
     const { color, hideInnerValue } = config;
+    const scoreValueClass = classnames({
+      'score-value-string': true,
+      'zero-value': value === 0
+    });
 
     return (
       <div className="c-score-comparison">
@@ -31,7 +38,10 @@ class ScoreComparison extends PureComponent {
               width: `calc(${ScoreComparison.getWidth(value)} + 2px)`
             }}
           >
-            {!hideInnerValue && <span className={`score-value-string ${(value === 0) && 'zero-value'}`}>{fixedValue(value)}</span>}
+            {!hideInnerValue &&
+              <span className={scoreValueClass}>
+                {fixedValue(value)}
+              </span>}
           </div>
           <div
             className="score-avg"

--- a/components/common/score-comparison/score-comparison-component.js
+++ b/components/common/score-comparison/score-comparison-component.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { fixedValue } from 'utils/value-parser';
 
 // styles
 import styles from './score-comparison-styles.scss';
@@ -16,7 +17,7 @@ class ScoreComparison extends PureComponent {
 
   render() {
     const { data, config } = this.props;
-    const { avg, min, max, value } = data;
+    const { avg, min, max, value, hideInnerValue } = data;
     const { color } = config;
 
     return (
@@ -30,7 +31,7 @@ class ScoreComparison extends PureComponent {
               width: `calc(${ScoreComparison.getWidth(value)} + 2px)`
             }}
           >
-            {!!value && <span className="score-value-string">{value}</span>}
+            {!hideInnerValue && <span className={`score-value-string ${(value === 0) && 'zero-value'}`}>{fixedValue(value)}</span>}
           </div>
           <div
             className="score-avg"
@@ -38,25 +39,29 @@ class ScoreComparison extends PureComponent {
           >
             <div className="legend">
               <span>Avg</span>
-              <span>{avg}</span>
+              <span>{fixedValue(avg)}</span>
             </div>
           </div>
-          <div
-            className="score-min"
-            style={{ left: ScoreComparison.getWidth(min) }}
-          >
-            <div className="legend">
-              <span>Min</span>
-              <span>{min}</span>
+
+          {
+            (min != undefined) && <div
+              className="score-min"
+              style={{ left: ScoreComparison.getWidth(min) }}
+            >
+              <div className="legend">
+                <span>Min</span>
+                <span>{fixedValue(min)}</span>
+              </div>
             </div>
-          </div>
+          }
+
           <div
             className="score-max"
             style={{ left: `calc(${ScoreComparison.getWidth(max)} + 1px)` }}
           >
             <div className="legend">
               <span>Max</span>
-              <span>{max}</span>
+              <span>{fixedValue(max)}</span>
             </div>
           </div>
         </div>

--- a/components/common/score-comparison/score-comparison-styles.scss
+++ b/components/common/score-comparison/score-comparison-styles.scss
@@ -24,6 +24,11 @@ $bar-height: 40px;
     > .score-value-string {
       font-size: $font-size-big;
     }
+
+    > .zero-value {
+      position: relative;
+      left: -25px;
+    }
   }
 
   > .score-bar > .score-avg {

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-accordion/companies-detail-accordion-component.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-accordion/companies-detail-accordion-component.js
@@ -38,7 +38,6 @@ class CompaniesDetailAccordion extends PureComponent {
               <ScoreComparison
                 data={{
                   avg: d.avg,
-                  min: d.min,
                   max: d.max,
                   value: d.value
                 }}

--- a/components/pages/mine-sites-detail/mine-sites-detail-accordion/mine-sites-detail-accordion-component.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-accordion/mine-sites-detail-accordion-component.js
@@ -31,7 +31,6 @@ class MineSitesDetailAccordion extends PureComponent {
               <ScoreComparison
                 data={{
                   avg: d.avg,
-                  min: d.min,
                   max: d.max,
                   value: d.value
                 }}

--- a/components/pages/results-detail/accordion/accordion-component.js
+++ b/components/pages/results-detail/accordion/accordion-component.js
@@ -34,10 +34,12 @@ class ResultsDetailAccordion extends PureComponent {
                   avg: d.avg,
                   min: d.min,
                   max: d.max,
-                  value: d.avg,
+                  value: d.avg
+                }}
+                config={{
+                  color: d.color,
                   hideInnerValue: true
                 }}
-                config={{ color: d.color }}
               />
             </div>
           </div>

--- a/components/pages/results-detail/accordion/accordion-component.js
+++ b/components/pages/results-detail/accordion/accordion-component.js
@@ -34,7 +34,8 @@ class ResultsDetailAccordion extends PureComponent {
                   avg: d.avg,
                   min: d.min,
                   max: d.max,
-                  value: d.value
+                  value: d.avg,
+                  hideInnerValue: true
                 }}
                 config={{ color: d.color }}
               />


### PR DESCRIPTION
## Overview

- No min value on the company detail page
- No min value on the mine site detail page
- Don't hide score when 0
- Fill bar with avg value on the overall results detail page
- No score value inside when on the overall results detail page
- Always show all values with 2 decimal values

## Testing instructions
Check if all of the above work.

## Pivotal task
[Pivotal](https://www.pivotaltracker.com/story/show/155933134)
[Basecamp](https://basecamp.com/1756858/projects/14775080/todos/344933483)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
