### PR TITLE
Fixes padding for list of mine sites

### DIFF
--- a/components/common/companies-list/companies-list-constants.js
+++ b/components/common/companies-list/companies-list-constants.js
@@ -11,7 +11,8 @@ export const TOOLTIP_TABLE_COLUMNS = [
         style: {
           backgroundColor: '#000',
           color: '#fff',
-          fontWeight: 500
+          fontWeight: 500,
+          paddingLeft: 15
         }
       }
     },
@@ -25,7 +26,8 @@ export const TOOLTIP_TABLE_COLUMNS = [
             <a>{name}</a>
           </Link>
         )
-      ]
+      ],
+      props: { style: { paddingLeft: 15 } }
     }
   },
   {
@@ -50,11 +52,15 @@ export const TOOLTIP_TABLE_COLUMNS = [
         style: {
           backgroundColor: '#000',
           color: '#fff',
-          fontWeight: 500
+          fontWeight: 500,
+          paddingRight: 15
         }
       }
     },
-    cell: { formatters: [commodities => commodities.map(commodity => commodity.name).join(', ')] }
+    cell: {
+      formatters: [commodities => commodities.map(commodity => commodity.name).join(', ')],
+      props: { style: { paddingRight: 15 } }
+    }
   }
 ];
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/999124/38200105-592dcd48-3693-11e8-8d0e-c2f390ba73ab.png)


## Overview
Fixes horizontal padding in the table shows the list of mine sites belonging to a company.

## Testing instructions
Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc.

## Pivotal task
https://www.pivotaltracker.com/story/show/156428657

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
