### PR TITLE
Remove document url from table on mine site detail

### DIFF
--- a/components/pages/mine-sites-detail/mine-sites-detail-assessments-table/mine-sites-detail-assessments-table-constants.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-assessments-table/mine-sites-detail-assessments-table-constants.js
@@ -11,15 +11,6 @@ export const ASSESSMENTS_TABLE_COLUMNS = [
     header: { label: 'Indicators' }
   },
   {
-    property: 'url',
-    header: { label: 'URL Address' },
-    cell: {
-      formatters: [
-        url => (url.label ? <a href={url.value} rel="noopener noreferrer">{url.label}</a> : '-')
-      ]
-    }
-  },
-  {
     property: 'downloadLink',
     header: { label: 'Select File' },
     cell: {

--- a/components/pages/mine-sites-detail/mine-sites-detail-assessments-table/mine-sites-detail-assessments-table-selectors.js
+++ b/components/pages/mine-sites-detail/mine-sites-detail-assessments-table/mine-sites-detail-assessments-table-selectors.js
@@ -9,10 +9,6 @@ export const parseAssessments = createSelector(
     id: dms.document.id,
     title: dms.document.name,
     indicators: (dms.indicators || []).length ? dms.indicators.map(indicator => indicator.code).join(', ') : '-',
-    url: {
-      label: dms.document.url ? `${dms.document.url.substring(0, 50)}...` : null,
-      value: dms.document.url
-    },
     downloadLink: dms.document['download-link']
   }))
 );


### PR DESCRIPTION
## Overview
Remove the URLs for the assessment table on mine site detail.

## Testing instructions
Check if the table still works without the URLs.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/156439788)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
