### PR TITLE
Remove spider chat from company detail page

### DIFF
--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-component.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-component.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 // global constants
-import { overallColors, measurementColors } from 'constants/graph-colors';
+import { measurementColors } from 'constants/graph-colors';
 
 // components
 import SpiderChart from 'components/charts/spiderchart';
@@ -27,7 +27,6 @@ import styles from './companies-detail-scores-breakdown-styles.scss';
 
 class CompaniesDetailScoresBreakDown extends PureComponent {
   static propTypes = {
-    overallScores: PropTypes.array.isRequired,
     mineSites: PropTypes.array.isRequired,
     breakdownScores: PropTypes.array.isRequired,
     shareholders: PropTypes.array.isRequired,
@@ -38,7 +37,7 @@ class CompaniesDetailScoresBreakDown extends PureComponent {
 
   render() {
     const {
-      company, overallScores, breakdownScores, mineSites,
+      company, breakdownScores, mineSites,
       shareholders, investmentDisputes, knownTaxJurisdictions
     } = this.props;
     const {
@@ -52,16 +51,6 @@ class CompaniesDetailScoresBreakDown extends PureComponent {
         <style jsx>{styles}</style>
         <div className="l-layout">
           {summary && <Summary content={summary}/>}
-          <div className="section overall-scores-container">
-            <div className="row center-md">
-              <div className="col-md-10">
-                <SpiderChart
-                  colors={overallColors}
-                  data={overallScores}
-                />
-              </div>
-            </div>
-          </div>
           <section className="section measurement-scores-container">
             <div className="row center-md -no-text-align">
               <div className="col-xs-12 col-md-10">

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-selectors.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-selectors.js
@@ -11,18 +11,6 @@ const investmentDisputes = state => (state.companies.list[0] || {})['investment-
 const knownTaxJurisdictions = state =>
   (state.companies.list[0] || {})['company-country-tax-jurisdictions'];
 
-export const getOverallScores = createSelector(
-  [scores],
-  (_scores = []) => {
-    const overallScores = _scores.filter(score => (score || {}).kind === 'overall_indicator');
-    return overallScores.map(score => ({
-      id: score.id,
-      name: score.label,
-      value: score.value
-    }));
-  }
-);
-
 export const parseShareholders = createSelector(
   [shareholders],
   (_shareholders = []) => orderBy(_shareholders, 'name', ['asc'])
@@ -111,7 +99,6 @@ export const parseKnownTaxJurisdictions = createSelector(
 );
 
 export default {
-  getOverallScores,
   getBreakdownScores,
   parseMineSitesScores,
   parseKnownTaxJurisdictions

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-styles.scss
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-scores-breakdown-styles.scss
@@ -46,22 +46,6 @@
     font-style: italic;
   }
 
-  .measurement-scores-container {
-    position: relative;
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 50%;
-      transform: translate(-50%, 0);
-      display: inline-block;
-      height: 2px;
-      width: 80%;
-      background-color: $color-6;
-    }
-  }
-
   .contextual-table {
     &:not(:first-child) {
       margin: 35px 0 0;

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/index.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 
 import CompaniesDetailScoresBreakdown from './companies-detail-scores-breakdown-component';
 import {
-  getOverallScores,
   getBreakdownScores,
   parseMineSitesScores,
   parseKnownTaxJurisdictions,
@@ -12,7 +11,6 @@ import {
 
 export default connect(
   state => ({
-    overallScores: getOverallScores(state),
     breakdownScores: getBreakdownScores(state),
     mineSites: parseMineSitesScores(state),
     shareholders: parseShareholders(state),


### PR DESCRIPTION
## Overview
Remove spider chart from company detail page.

## Testing instructions
Check if the spider chart is not there and the rest still works.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/156439571)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
