### PR TITLE
Change max and ticks values for bar charts

### DIFF
--- a/components/charts/barschart/barschart-config.js
+++ b/components/charts/barschart/barschart-config.js
@@ -13,12 +13,12 @@ export default {
   xAxisInterval: 'preserveEnd',
   // yAxis
   YaxisLine: false,
-  domain: [0, 1],
   YAxisTick: {},
+  domain: [0, 6],
+  YAxisTicks: ['0.000', '1.000', '2.000', '3.000', '4.000', '5.000', '6.000'],
   // styling
   strokeDasharray: '3',
   fill: 'none',
-  YAxisTicks: ['0.000', '0.200', '0.400', '0.600', '0.800', '1.000'],
   // bar
   barDataKey: 'value',
   setBarFill: () => '#ddd',

--- a/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-constants.js
+++ b/components/pages/companies-detail/companies-detail-scores-breakdown/companies-detail-overall-measurements/companies-detail-overall-measurements-constants.js
@@ -1,6 +1,8 @@
 export const CHART_CONFIG = {
   xAxis: false,
   xAxisHeight: 5,
+  domain: [0, 1],
+  YAxisTicks: ['0.000', '0.200', '0.400', '0.600', '0.800', '1.000'],
   setBarFill: item => item.currentCompany ? '#272626' : '#f2f2f2'
 };
 


### PR DESCRIPTION
Change the max value of the bars chart from 1 to 6, this pr can't be merged until the data is matching.