### PR TITLE
Remove url column from library table

### DIFF
--- a/components/pages/library/library-table/library-table-constants.js
+++ b/components/pages/library/library-table/library-table-constants.js
@@ -13,15 +13,6 @@ export const DOCUMENTS_TABLE_COLUMNS = [
     header: { label: 'Source Document' }
   },
   {
-    property: 'url',
-    header: { label: 'URL Address' },
-    cell: {
-      formatters: [
-        url => (url.label ? <a href={url.value} rel="noopener noreferrer">{url.label}</a> : '-')
-      ]
-    }
-  },
-  {
     property: 'downloadLink',
     header: { label: 'Download' },
     cell: {

--- a/components/pages/library/library-table/library-table-selectors.js
+++ b/components/pages/library/library-table/library-table-selectors.js
@@ -9,10 +9,6 @@ export const parseDocuments = createSelector(
     id: document.id,
     name: document.name,
     company: (document.company || {}).name || '-',
-    url: {
-      label: document.url ? `${document.url.substring(0, 50)}...` : null,
-      value: document.url
-    },
     downloadLink: document['download-link']
   }))
 );


### PR DESCRIPTION
## Overview
Remove the url column from the libraries table.

## Testing instructions
Check document library page.

## Pivotal task
[Basecamp](https://basecamp.com/1756858/projects/14775080/todos/347877648)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
