### PR TITLE
Fix download summary buttons

### DIFF
--- a/components/pages/index-homepage/index-page.js
+++ b/components/pages/index-homepage/index-page.js
@@ -46,7 +46,6 @@ class IndexPage extends PureComponent {
                   >
                     <a
                       className="summary-link"
-                      download
                     >
                       Download Summary
                     </a>
@@ -164,13 +163,16 @@ class IndexPage extends PureComponent {
                     </Link>
                   </Button>
 
-                  <a
-                    href="/resources/RMI_2018_report-WEB.pdf"
-                    className="summary-link"
-                    download
+                  <Link
+                    route="downloads"
+                    params={{ language: currentLanguage }}
                   >
-                    Download Summary
-                  </a>
+                    <a
+                      className="summary-link"
+                    >
+                      Download Summary
+                    </a>
+                  </Link>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Overview
One of the download summary buttons on the home page wasn't redirecting to the `downloads` page and when redirecting, if clicking with `cmd` it would download the page instead of redirecting.

## Testing instructions
Test both download summary buttons on the home page, including opening it on a new tab.

## Pivotal task
[Basecamp](https://basecamp.com/1756858/projects/14775080/todos/350827858)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
